### PR TITLE
Disable Google auth until client ID available

### DIFF
--- a/src/screens/LoginScreen.jsx
+++ b/src/screens/LoginScreen.jsx
@@ -1,40 +1,16 @@
-import React, { useState, useEffect } from 'react';
-import {
-  View,
-  Text,
-  Image,
-  Pressable,
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-} from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, Image, Pressable, Alert, KeyboardAvoidingView, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import * as WebBrowser from 'expo-web-browser';
-import * as Google from 'expo-auth-session/providers/google';
 import AuthCard from '../components/AuthCard';
 import TextField from '../components/TextField';
 import PasswordField from '../components/PasswordField';
 import GoogleButton from '../components/GoogleButton';
 import { loginSchema } from '../utils/validation';
 
-WebBrowser.maybeCompleteAuthSession();
-
 export default function LoginScreen({ navigation }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [errors, setErrors] = useState({});
-  const [request, response, promptAsync] = Google.useAuthRequest({
-    webClientId: process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID,
-    androidClientId: process.env.EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID,
-    iosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID,
-    expoClientId: process.env.EXPO_PUBLIC_GOOGLE_EXPO_CLIENT_ID,
-  });
-
-  useEffect(() => {
-    if (response?.type === 'success') {
-      Alert.alert('Logged in with Google!');
-    }
-  }, [response]);
 
   const handleSubmit = async () => {
     try {
@@ -56,12 +32,11 @@ export default function LoginScreen({ navigation }) {
     <SafeAreaView className="flex-1 bg-peach-100">
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        className="flex-1 justify-center"
-      >
-        <View className="items-center mb-6">
+        className="flex-1 justify-center">
+        <View className="mb-6 items-center">
           <Image
             source={require('../../assets/logo.png')}
-            className="w-40 h-24"
+            className="h-24 w-40"
             resizeMode="contain"
           />
         </View>
@@ -88,18 +63,16 @@ export default function LoginScreen({ navigation }) {
             onPress={handleSubmit}
             accessibilityRole="button"
             accessibilityLabel="Log in"
-            className="items-center rounded-full bg-peach-400 py-3 mt-6 shadow-md"
-            style={({ pressed }) => ({ opacity: pressed ? 0.8 : 1 })}
-          >
+            className="mt-6 items-center rounded-full bg-peach-400 py-3 shadow-md"
+            style={({ pressed }) => ({ opacity: pressed ? 0.8 : 1 })}>
             <Text className="font-semibold text-white">Log In</Text>
           </Pressable>
-          <GoogleButton onPress={() => promptAsync()} />
+          <GoogleButton onPress={() => Alert.alert('Google sign-in is not available yet')} />
           <Pressable
             className="mt-3"
             onPress={() => {}}
             accessibilityRole="link"
-            accessibilityLabel="Forgot password"
-          >
+            accessibilityLabel="Forgot password">
             <Text className="text-center text-peach-400 underline">Forgot password?</Text>
           </Pressable>
         </AuthCard>
@@ -108,8 +81,7 @@ export default function LoginScreen({ navigation }) {
           <Pressable
             onPress={() => navigation.navigate('SignUp')}
             accessibilityRole="link"
-            accessibilityLabel="Sign Up"
-          >
+            accessibilityLabel="Sign Up">
             <Text className="font-bold text-peach-400 underline">Sign Up</Text>
           </Pressable>
         </View>

--- a/src/screens/SignUpScreen.jsx
+++ b/src/screens/SignUpScreen.jsx
@@ -1,23 +1,11 @@
-import React, { useState, useEffect } from 'react';
-import {
-  View,
-  Text,
-  Image,
-  Pressable,
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-} from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, Image, Pressable, Alert, KeyboardAvoidingView, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import * as WebBrowser from 'expo-web-browser';
-import * as Google from 'expo-auth-session/providers/google';
 import AuthCard from '../components/AuthCard';
 import TextField from '../components/TextField';
 import PasswordField from '../components/PasswordField';
 import GoogleButton from '../components/GoogleButton';
 import { signUpSchema } from '../utils/validation';
-
-WebBrowser.maybeCompleteAuthSession();
 
 export default function SignUpScreen({ navigation }) {
   const [name, setName] = useState('');
@@ -25,18 +13,6 @@ export default function SignUpScreen({ navigation }) {
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [errors, setErrors] = useState({});
-  const [request, response, promptAsync] = Google.useAuthRequest({
-    webClientId: process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID,
-    androidClientId: process.env.EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID,
-    iosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID,
-    expoClientId: process.env.EXPO_PUBLIC_GOOGLE_EXPO_CLIENT_ID,
-  });
-
-  useEffect(() => {
-    if (response?.type === 'success') {
-      Alert.alert('Signed up with Google!');
-    }
-  }, [response]);
 
   const handleSubmit = async () => {
     try {
@@ -61,12 +37,11 @@ export default function SignUpScreen({ navigation }) {
     <SafeAreaView className="flex-1 bg-peach-100">
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        className="flex-1 justify-center"
-      >
-        <View className="items-center mb-6">
+        className="flex-1 justify-center">
+        <View className="mb-6 items-center">
           <Image
             source={require('../../assets/logo.png')}
-            className="w-40 h-24"
+            className="h-24 w-40"
             resizeMode="contain"
           />
         </View>
@@ -108,20 +83,18 @@ export default function SignUpScreen({ navigation }) {
             onPress={handleSubmit}
             accessibilityRole="button"
             accessibilityLabel="Create Account"
-            className="items-center rounded-full bg-peach-400 py-3 mt-6 shadow-md"
-            style={({ pressed }) => ({ opacity: pressed ? 0.8 : 1 })}
-          >
+            className="mt-6 items-center rounded-full bg-peach-400 py-3 shadow-md"
+            style={({ pressed }) => ({ opacity: pressed ? 0.8 : 1 })}>
             <Text className="font-semibold text-white">Create Account</Text>
           </Pressable>
-          <GoogleButton onPress={() => promptAsync()} />
+          <GoogleButton onPress={() => Alert.alert('Google sign-in is not available yet')} />
         </AuthCard>
         <View className="mt-6 flex-row justify-center">
           <Text className="text-sub">Already have an account? </Text>
           <Pressable
             onPress={() => navigation.navigate('Login')}
             accessibilityRole="link"
-            accessibilityLabel="Log In"
-          >
+            accessibilityLabel="Log In">
             <Text className="font-bold text-peach-400 underline">Log In</Text>
           </Pressable>
         </View>


### PR DESCRIPTION
## Summary
- remove Google auth session code from login and sign up screens
- show Google button with placeholder alert instead of authentication

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689e023bbf0483248162dadad1777d78