### PR TITLE
refactor auth screens

### DIFF
--- a/src/components/AuthLayout.jsx
+++ b/src/components/AuthLayout.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { SafeAreaView, KeyboardAvoidingView, Platform } from 'react-native';
+
+export default function AuthLayout({ children }) {
+  return (
+    <SafeAreaView className="flex-1 bg-white">
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        className="flex-1 justify-center p-6">
+        {children}
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}

--- a/src/screens/LoginScreen.jsx
+++ b/src/screens/LoginScreen.jsx
@@ -1,14 +1,6 @@
 import React, { useState } from 'react';
-import {
-  SafeAreaView,
-  View,
-  Text,
-  TextInput,
-  TouchableOpacity,
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-} from 'react-native';
+import { View, Text, TextInput, TouchableOpacity, Alert } from 'react-native';
+import AuthLayout from '../components/AuthLayout';
 import { signIn } from '../utils/auth';
 
 export default function LoginScreen({ navigation }) {
@@ -36,44 +28,38 @@ export default function LoginScreen({ navigation }) {
   };
 
   return (
-    <SafeAreaView className="flex-1 bg-white">
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        className="flex-1 justify-center p-6">
-        <View className="mb-8">
-          <Text className="text-3xl font-bold text-center text-black">TechnoMart</Text>
-        </View>
-        <View className="gap-4">
-          <TextInput
-            className="rounded border border-gray-300 p-3"
-            placeholder="Email"
-            value={email}
-            onChangeText={setEmail}
-            keyboardType="email-address"
-            autoCapitalize="none"
-          />
-          <TextInput
-            className="rounded border border-gray-300 p-3"
-            placeholder="Password"
-            value={password}
-            onChangeText={setPassword}
-            secureTextEntry
-          />
-          <TouchableOpacity
-            className="mt-2 rounded bg-blue-500 p-3"
-            onPress={handleLogin}
-            disabled={loading}>
-            <Text className="text-center font-semibold text-white">
-              {loading ? 'Loading...' : 'Log In'}
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            onPress={() => navigation.navigate('SignUp')}
-            className="pt-2">
-            <Text className="text-center text-blue-600">Create an account</Text>
-          </TouchableOpacity>
-        </View>
-      </KeyboardAvoidingView>
-    </SafeAreaView>
+    <AuthLayout>
+      <View className="mb-8">
+        <Text className="text-center text-3xl font-bold text-black">TechnoMart</Text>
+      </View>
+      <View className="gap-4">
+        <TextInput
+          className="rounded border border-gray-300 p-3"
+          placeholder="Email"
+          value={email}
+          onChangeText={setEmail}
+          keyboardType="email-address"
+          autoCapitalize="none"
+        />
+        <TextInput
+          className="rounded border border-gray-300 p-3"
+          placeholder="Password"
+          value={password}
+          onChangeText={setPassword}
+          secureTextEntry
+        />
+        <TouchableOpacity
+          className="mt-2 rounded bg-blue-500 p-3"
+          onPress={handleLogin}
+          disabled={loading}>
+          <Text className="text-center font-semibold text-white">
+            {loading ? 'Loading...' : 'Log In'}
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={() => navigation.navigate('SignUp')} className="pt-2">
+          <Text className="text-center text-blue-600">Create an account</Text>
+        </TouchableOpacity>
+      </View>
+    </AuthLayout>
   );
 }

--- a/src/screens/SignUpScreen.jsx
+++ b/src/screens/SignUpScreen.jsx
@@ -1,14 +1,6 @@
 import React, { useState } from 'react';
-import {
-  SafeAreaView,
-  View,
-  Text,
-  TextInput,
-  TouchableOpacity,
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-} from 'react-native';
+import { View, Text, TextInput, TouchableOpacity, Alert } from 'react-native';
+import AuthLayout from '../components/AuthLayout';
 import { register } from '../utils/auth';
 
 export default function SignUpScreen({ navigation }) {
@@ -28,7 +20,7 @@ export default function SignUpScreen({ navigation }) {
     try {
       const id = await register(name, email, password);
       Alert.alert('Account created', `User ID: ${id}`, [
-        { text: 'OK', onPress: () => navigation.navigate('Login') }
+        { text: 'OK', onPress: () => navigation.navigate('Login') },
       ]);
       setName('');
       setEmail('');
@@ -42,57 +34,51 @@ export default function SignUpScreen({ navigation }) {
   };
 
   return (
-    <SafeAreaView className="flex-1 bg-white">
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        className="flex-1 justify-center p-6">
-        <View className="mb-8">
-          <Text className="text-3xl font-bold text-center text-black">Join TechnoMart</Text>
-        </View>
-        <View className="gap-4">
-          <TextInput
-            className="rounded border border-gray-300 p-3"
-            placeholder="Name"
-            value={name}
-            onChangeText={setName}
-          />
-          <TextInput
-            className="rounded border border-gray-300 p-3"
-            placeholder="Email"
-            value={email}
-            onChangeText={setEmail}
-            keyboardType="email-address"
-            autoCapitalize="none"
-          />
-          <TextInput
-            className="rounded border border-gray-300 p-3"
-            placeholder="Password"
-            value={password}
-            onChangeText={setPassword}
-            secureTextEntry
-          />
-          <TextInput
-            className="rounded border border-gray-300 p-3"
-            placeholder="Confirm Password"
-            value={confirm}
-            onChangeText={setConfirm}
-            secureTextEntry
-          />
-          <TouchableOpacity
-            className="mt-2 rounded bg-green-500 p-3"
-            onPress={handleRegister}
-            disabled={loading}>
-            <Text className="text-center font-semibold text-white">
-              {loading ? 'Loading...' : 'Sign Up'}
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            onPress={() => navigation.navigate('Login')}
-            className="pt-2">
-            <Text className="text-center text-blue-600">Back to login</Text>
-          </TouchableOpacity>
-        </View>
-      </KeyboardAvoidingView>
-    </SafeAreaView>
+    <AuthLayout>
+      <View className="mb-8">
+        <Text className="text-center text-3xl font-bold text-black">Join TechnoMart</Text>
+      </View>
+      <View className="gap-4">
+        <TextInput
+          className="rounded border border-gray-300 p-3"
+          placeholder="Name"
+          value={name}
+          onChangeText={setName}
+        />
+        <TextInput
+          className="rounded border border-gray-300 p-3"
+          placeholder="Email"
+          value={email}
+          onChangeText={setEmail}
+          keyboardType="email-address"
+          autoCapitalize="none"
+        />
+        <TextInput
+          className="rounded border border-gray-300 p-3"
+          placeholder="Password"
+          value={password}
+          onChangeText={setPassword}
+          secureTextEntry
+        />
+        <TextInput
+          className="rounded border border-gray-300 p-3"
+          placeholder="Confirm Password"
+          value={confirm}
+          onChangeText={setConfirm}
+          secureTextEntry
+        />
+        <TouchableOpacity
+          className="mt-2 rounded bg-green-500 p-3"
+          onPress={handleRegister}
+          disabled={loading}>
+          <Text className="text-center font-semibold text-white">
+            {loading ? 'Loading...' : 'Sign Up'}
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={() => navigation.navigate('Login')} className="pt-2">
+          <Text className="text-center text-blue-600">Back to login</Text>
+        </TouchableOpacity>
+      </View>
+    </AuthLayout>
   );
 }


### PR DESCRIPTION
## Summary
- refactor login and signup screens to use shared AuthLayout
- centralize auth page layout for consistent minimal design

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689ff80847c48324a41794fd128b233c