### PR TITLE
refactor: extract auth components for login and signup

### DIFF
--- a/src/components/AuthButton.jsx
+++ b/src/components/AuthButton.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { TouchableOpacity, Text } from 'react-native';
+
+export default function AuthButton({ title, onPress, loading, className = 'bg-blue-500' }) {
+  return (
+    <TouchableOpacity
+      className={`mt-2 rounded p-3 ${className}`.trim()}
+      onPress={onPress}
+      disabled={loading}>
+      <Text className="text-center font-semibold text-white">{loading ? 'Loading...' : title}</Text>
+    </TouchableOpacity>
+  );
+}

--- a/src/components/AuthInput.jsx
+++ b/src/components/AuthInput.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { TextInput } from 'react-native';
+
+export default function AuthInput({ className = '', ...props }) {
+  return (
+    <TextInput className={`rounded border border-gray-300 p-3 ${className}`.trim()} {...props} />
+  );
+}

--- a/src/screens/LoginScreen.jsx
+++ b/src/screens/LoginScreen.jsx
@@ -3,12 +3,13 @@ import {
   SafeAreaView,
   View,
   Text,
-  TextInput,
   TouchableOpacity,
   Alert,
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
+import AuthInput from '../components/AuthInput';
+import AuthButton from '../components/AuthButton';
 import { signIn } from '../utils/auth';
 
 export default function LoginScreen({ navigation }) {
@@ -41,35 +42,24 @@ export default function LoginScreen({ navigation }) {
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         className="flex-1 justify-center p-6">
         <View className="mb-8">
-          <Text className="text-3xl font-bold text-center text-black">TechnoMart</Text>
+          <Text className="text-center text-3xl font-bold text-black">TechnoMart</Text>
         </View>
         <View className="gap-4">
-          <TextInput
-            className="rounded border border-gray-300 p-3"
+          <AuthInput
             placeholder="Email"
             value={email}
             onChangeText={setEmail}
             keyboardType="email-address"
             autoCapitalize="none"
           />
-          <TextInput
-            className="rounded border border-gray-300 p-3"
+          <AuthInput
             placeholder="Password"
             value={password}
             onChangeText={setPassword}
             secureTextEntry
           />
-          <TouchableOpacity
-            className="mt-2 rounded bg-blue-500 p-3"
-            onPress={handleLogin}
-            disabled={loading}>
-            <Text className="text-center font-semibold text-white">
-              {loading ? 'Loading...' : 'Log In'}
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            onPress={() => navigation.navigate('SignUp')}
-            className="pt-2">
+          <AuthButton title="Log In" onPress={handleLogin} loading={loading} />
+          <TouchableOpacity onPress={() => navigation.navigate('SignUp')} className="pt-2">
             <Text className="text-center text-blue-600">Create an account</Text>
           </TouchableOpacity>
         </View>

--- a/src/screens/SignUpScreen.jsx
+++ b/src/screens/SignUpScreen.jsx
@@ -3,12 +3,13 @@ import {
   SafeAreaView,
   View,
   Text,
-  TextInput,
   TouchableOpacity,
   Alert,
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
+import AuthInput from '../components/AuthInput';
+import AuthButton from '../components/AuthButton';
 import { register } from '../utils/auth';
 
 export default function SignUpScreen({ navigation }) {
@@ -28,7 +29,7 @@ export default function SignUpScreen({ navigation }) {
     try {
       const id = await register(name, email, password);
       Alert.alert('Account created', `User ID: ${id}`, [
-        { text: 'OK', onPress: () => navigation.navigate('Login') }
+        { text: 'OK', onPress: () => navigation.navigate('Login') },
       ]);
       setName('');
       setEmail('');
@@ -47,48 +48,36 @@ export default function SignUpScreen({ navigation }) {
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         className="flex-1 justify-center p-6">
         <View className="mb-8">
-          <Text className="text-3xl font-bold text-center text-black">Join TechnoMart</Text>
+          <Text className="text-center text-3xl font-bold text-black">Join TechnoMart</Text>
         </View>
         <View className="gap-4">
-          <TextInput
-            className="rounded border border-gray-300 p-3"
-            placeholder="Name"
-            value={name}
-            onChangeText={setName}
-          />
-          <TextInput
-            className="rounded border border-gray-300 p-3"
+          <AuthInput placeholder="Name" value={name} onChangeText={setName} />
+          <AuthInput
             placeholder="Email"
             value={email}
             onChangeText={setEmail}
             keyboardType="email-address"
             autoCapitalize="none"
           />
-          <TextInput
-            className="rounded border border-gray-300 p-3"
+          <AuthInput
             placeholder="Password"
             value={password}
             onChangeText={setPassword}
             secureTextEntry
           />
-          <TextInput
-            className="rounded border border-gray-300 p-3"
+          <AuthInput
             placeholder="Confirm Password"
             value={confirm}
             onChangeText={setConfirm}
             secureTextEntry
           />
-          <TouchableOpacity
-            className="mt-2 rounded bg-green-500 p-3"
+          <AuthButton
+            title="Sign Up"
             onPress={handleRegister}
-            disabled={loading}>
-            <Text className="text-center font-semibold text-white">
-              {loading ? 'Loading...' : 'Sign Up'}
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            onPress={() => navigation.navigate('Login')}
-            className="pt-2">
+            loading={loading}
+            className="bg-green-500"
+          />
+          <TouchableOpacity onPress={() => navigation.navigate('Login')} className="pt-2">
             <Text className="text-center text-blue-600">Back to login</Text>
           </TouchableOpacity>
         </View>


### PR DESCRIPTION
## Summary
- create reusable `AuthInput` and `AuthButton` components for consistent auth UI
- refactor login and signup screens to use new components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689ff80847c48324a41794fd128b233c